### PR TITLE
fix: Check that CMSReportingOnly exists before access. SIGMAS-172

### DIFF
--- a/src/Middleware/SecurityHeaderMiddleware.php
+++ b/src/Middleware/SecurityHeaderMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Signify\Middleware;
 
 use Signify\Extensions\SecurityHeaderSiteconfigExtension;
@@ -197,7 +198,8 @@ class SecurityHeaderMiddleware implements HTTPMiddleware
     /**
      * Is the CSPReportingOnly field safe to read.
      *
-     * If the module is installed and the codebase is flushed before the database has been built, accessing SiteConfig causes an error.
+     * If the module is installed and the codebase is flushed before the database has been built,
+     * accessing SiteConfig causes an error.
      *
      * @return boolean
      */


### PR DESCRIPTION
CWP deployments create the codebase, then run flush, and then run
/dev/build.

Silverstripe assumes that SiteConfig is up-to-date when
SilverStripe\SiteConfig\SiteConfig::current_site_config() is called from
Signify\Middleware\SecurityHeaderMiddleware::isCSPReportingOnly(). If it
isn't, an error is thrown.

To avoid this, verify that SiteConfig has the field before trying to
access it.