### PR TITLE
fix: Add silverstripe/framework constraint for ClassInfo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "silverstripe/vendor-plugin": "^1.0",
-    "silverstripe/framework": "^4.0",
+    "silverstripe/framework": "^4.6",
     "silverstripe/cms": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
The 2.0.1 release inadvertently depends on ClassInfo::classesWithExtension(), which was introduced in Silverstripe framework 4.6.0.

This fix changes the constraint for silverstripe/framework, to require 4.6.0 or higher.