### PR TITLE
fix: Ensure pagination doesn't affect filtering or deleting violations (SS4)

### DIFF
--- a/src/Forms/GridField/GridFieldDeleteRelationsButton.php
+++ b/src/Forms/GridField/GridFieldDeleteRelationsButton.php
@@ -274,7 +274,11 @@ class GridFieldDeleteRelationsButton implements GridField_HTMLProvider, GridFiel
         }
 
         // Ensure data objects are filtered to only include items in this gridfield.
-        $filters['ID'] = $gridField->getManipulatedList()->column('ID');
+        $list = $gridField->getManipulatedList();
+        if (method_exists($list, 'limit')) {
+            $list = $list->limit(null);
+        }
+        $filters['ID'] = $list->column('ID');
         if (empty($filters['ID'])) {
             $deletions = new ArrayList();
         } else {


### PR DESCRIPTION
Because the gridfield list is paginated, and the IDs are fetched by filtering on that list, the IDs could only be pulled from the active page in the gridfield.
Remove the pagination limit prior to filtering.