### PR TITLE
fix: Ensure pagination doesn't affect filtering or deleting violations (SS3)

### DIFF
--- a/code/Forms/GridField/GridFieldDeleteRelationsButton.php
+++ b/code/Forms/GridField/GridFieldDeleteRelationsButton.php
@@ -272,7 +272,11 @@ class GridFieldDeleteRelationsButton extends SS_Object implements
         }
 
         // Ensure data objects are filtered to only include items in this gridfield.
-        $filters['ID'] = $gridField->getManipulatedList()->column('ID');
+        $list = $gridField->getManipulatedList();
+        if (method_exists($list, 'limit')) {
+            $list = $list->limit(null);
+        }
+        $filters['ID'] = $list->column('ID');
         if (empty($filters['ID'])) {
             $deletions = new ArrayList();
         } else {


### PR DESCRIPTION
Because the gridfield list is paginated, and the IDs are fetched by filtering on that list, the IDs could only be pulled from the active page in the gridfield.
Remove the pagination limit prior to filtering.