### PR TITLE
Fix isSameOrigin() when webiste resides in subfolder

### DIFF
--- a/src/Controllers/CSPViolationsController.php
+++ b/src/Controllers/CSPViolationsController.php
@@ -215,7 +215,7 @@ class CSPViolationsController extends Controller
         }
 
         // If not using report-to, or the origin header is set, only allow same origin requests.
-        return $origin == rtrim(Director::absoluteBaseURL(), '/');
+        return $origin == Director::protocolAndHost();
     }
 
     /**


### PR DESCRIPTION
When the website resides in a subfolder, `rtrim(Director::absoluteBaseURL(), '/')` returns a full path to the base of the website, eg : `http://example.com/ss-site/`. This replaces that logic with `Director::protocolAndHost()` which then matches `$request->getHeader('origin')`.