### PR TITLE
fix: remove direct calls to jobData for php8 compatibility TUMMAS-72

### DIFF
--- a/src/Jobs/RemoveOldCSPViolationsJob.php
+++ b/src/Jobs/RemoveOldCSPViolationsJob.php
@@ -30,9 +30,9 @@ class RemoveOldCSPViolationsJob extends AbstractQueuedJob
 
         $date = new DateTime();
         $date->sub($retention);
-        $this->jobData->retentionDate = $date->format(DateTime::ATOM);
+        $this->retentionDate = $date->format(DateTime::ATOM);
 
-        $this->jobData->reportsDeleted = 0;
+        $this->reportsDeleted = 0;
 
         $this->totalSteps = $this->getItemsList()->count();
     }
@@ -61,12 +61,12 @@ class RemoveOldCSPViolationsJob extends AbstractQueuedJob
             DB::get_conn()->transactionEnd();
         }
 
-        $this->jobData->reportsDeleted += $delta;
+        $this->reportsDeleted += $delta;
         $this->currentStep += $delta;
 
         if ($delta < $batchSize) {
             $this->isComplete = true;
-            print 'Removed ' . number_format($this->jobData->reportsDeleted) . ' reports.' . "\n";
+            print 'Removed ' . number_format($this->reportsDeleted) . ' reports.' . "\n";
 
             $deletionJob = new RemoveUnreferencedCSPDocumentJob();
             $jobId = singleton(QueuedJobService::class)->queueJob($deletionJob);
@@ -83,7 +83,7 @@ class RemoveOldCSPViolationsJob extends AbstractQueuedJob
 
     private function getItemsList(): DataList
     {
-        return CSPViolation::get()->filter(['ReportedTime:LessThan' => $this->jobData->retentionDate]);
+        return CSPViolation::get()->filter(['ReportedTime:LessThan' => $this->retentionDate]);
     }
 }
 

--- a/src/Jobs/RemoveUnreferencedCSPDocumentJob.php
+++ b/src/Jobs/RemoveUnreferencedCSPDocumentJob.php
@@ -14,8 +14,8 @@ class RemoveUnreferencedCSPDocumentJob extends AbstractQueuedJob
 
     public function setup()
     {
-        $this->jobData->lastSeenID = -1;
-        $this->jobData->documentsDeleted = 0;
+        $this->lastSeenID = -1;
+        $this->documentsDeleted = 0;
         $this->totalSteps = CSPDocument::get()->count();
     }
 
@@ -34,7 +34,7 @@ class RemoveUnreferencedCSPDocumentJob extends AbstractQueuedJob
 
             $lastDocument = $documents->last();
             if ($lastDocument) {
-                $this->jobData->lastSeenID = $lastDocument->ID;
+                $this->lastSeenID = $lastDocument->ID;
                 unset($lastDocument);
             }
 
@@ -54,12 +54,12 @@ class RemoveUnreferencedCSPDocumentJob extends AbstractQueuedJob
             DB::get_conn()->transactionEnd();
         }
 
-        $this->jobData->documentsDeleted += $deleted;
+        $this->documentsDeleted += $deleted;
         $this->currentStep += $delta;
 
         if ($delta < $batchSize) {
             $this->isComplete = true;
-            print 'Removed ' . number_format($this->jobData->documentsDeleted) . ' unreferenced document URIs.';
+            print 'Removed ' . number_format($this->documentsDeleted) . ' unreferenced document URIs.';
         }
     }
 
@@ -71,7 +71,7 @@ class RemoveUnreferencedCSPDocumentJob extends AbstractQueuedJob
     private function getItemsList(): DataList
     {
         return CSPDocument::get()
-            ->filter(['ID:GreaterThan' => $this->jobData->lastSeenID])
+            ->filter(['ID:GreaterThan' => $this->lastSeenID])
             ->sort('ID');
     }
 }


### PR DESCRIPTION
Accessing properties via jobData triggers 'Attempt to assign property on null' errors after PHP8 upgrade. Changed to access job properties as recommended in the [queued jobs module](https://github.com/symbiote/silverstripe-queuedjobs) documentation.