### PR TITLE
Support for Silverstripe 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "issues": "https://github.com/signify-nz/silverstripe-security-headers/issues"
   },
   "require": {
-    "silverstripe/vendor-plugin": "^1.0",
-    "silverstripe/framework": "^4.6",
-    "silverstripe/cms": "^4.0",
-    "symbiote/silverstripe-queuedjobs": "^4.8"
+    "silverstripe/vendor-plugin": "^1.0 || ^2.0",
+    "silverstripe/framework": "^4.6 || ^5.0",
+    "silverstripe/cms": "^4.0 || ^5.0",
+    "symbiote/silverstripe-queuedjobs": "^4.8 || ^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "silverstripe/framework": "^4.10",
+    "silverstripe/framework": "^4.10 || ^5.0",
     "squizlabs/php_codesniffer": "^3.0"
   },
   "suggest": {


### PR DESCRIPTION
This expands the version restraints to include both Silverstripe 4 and 5.

We have tested this successfully on Silverstripe 5 with no issues. My suggestion would be to tag this update within the existing v2.* releases so no project composer changes are required with existing websites, and so any new features in this module are back-ported. 