### PR TITLE
Update SecurityHeaderMiddleware.php

### DIFF
--- a/src/Middleware/SecurityHeaderMiddleware.php
+++ b/src/Middleware/SecurityHeaderMiddleware.php
@@ -222,12 +222,13 @@ class SecurityHeaderMiddleware implements HTTPMiddleware
     {
         if ($this->isReporting()) {
             // Add or update report-uri directive.
-            if (strpos($cspHeader, 'report-uri')) {
-                $cspHeader = str_replace('report-uri', $this->getReportURIDirective(), $cspHeader);
-            } else {
-                $cspHeader = rtrim($cspHeader, ';') . "; {$this->getReportURIDirective()};";
+            if($cspHeader) {
+                if (strpos($cspHeader, 'report-uri')) {
+                    $cspHeader = str_replace('report-uri', $this->getReportURIDirective(), $cspHeader);
+                } else {
+                    $cspHeader = rtrim($cspHeader, ';') . "; {$this->getReportURIDirective()};";
+                }
             }
-
             // Add report-to directive.
             // Note that unlike report-uri, only the first endpoint is used if multiple are declared.
             if ($this->config()->get('use_report_to')) {

--- a/src/Middleware/SecurityHeaderMiddleware.php
+++ b/src/Middleware/SecurityHeaderMiddleware.php
@@ -229,6 +229,9 @@ class SecurityHeaderMiddleware implements HTTPMiddleware
                     $cspHeader = rtrim($cspHeader, ';') . "; {$this->getReportURIDirective()};";
                 }
             }
+            else {
+                $cspHeader = $this->getReportURIDirective() . ';';
+            }
             // Add report-to directive.
             // Note that unlike report-uri, only the first endpoint is used if multiple are declared.
             if ($this->config()->get('use_report_to')) {


### PR DESCRIPTION
Fix PHP 8.1 deprecation warning for using null values in strpos and rtrim.